### PR TITLE
MNMS-166 🚧 feat(helm): nginx-client & nginx-admin 차트 및 Dockerfile 구성

### DIFF
--- a/charts/nginx-admin/Chart.yaml
+++ b/charts/nginx-admin/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: nginx-admin
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/nginx-admin/Dockerfile
+++ b/charts/nginx-admin/Dockerfile
@@ -1,0 +1,28 @@
+# 빌드
+FROM node:22 AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+# 배포
+FROM nginx:latest
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+
+RUN mkdir -p /app/log/nginx/client && chown -R nginx:nginx /app/log && chmod -R 755 /app/log
+
+RUN rm -f /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/charts/nginx-admin/nginx.conf
+++ b/charts/nginx-admin/nginx.conf
@@ -1,0 +1,37 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /app/log/nginx/admin/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /app/log/nginx/admin/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/charts/nginx-admin/templates/_helpers.tpl
+++ b/charts/nginx-admin/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx-admin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx.admin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx.admin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nginx.admin.labels" -}}
+helm.sh/chart: {{ include "nginx.admin.chart" . }}
+{{ include "nginx.admin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nginx.admin.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nginx.admin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx.admin.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nginx.admin.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/nginx-admin/templates/configmap.yaml
+++ b/charts/nginx-admin/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nginx-admin.fullname" . }}-config
+data:
+  nginx.conf: |
+{{ .Files.Get "nginx.conf" | indent 4 }}

--- a/charts/nginx-admin/templates/deployment.yaml
+++ b/charts/nginx-admin/templates/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "nginx-client.fullname" . }}   # nginx-admin이면 "nginx-admin.fullname"
+  name: {{ include "nginx-admin.fullname" . }}
   labels:
-    {{- include "nginx-client.labels" . | nindent 4 }}
+    {{- include "nginx-admin.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "nginx-client.selectorLabels" . | nindent 6 }}
+      {{- include "nginx-admin.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "nginx-client.selectorLabels" . | nindent 8 }}
+        {{- include "nginx-admin.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: nginx
@@ -27,4 +27,4 @@ spec:
       volumes:
         - name: nginx-config
           configMap:
-            name: {{ include "nginx-client.fullname" . }}-config
+            name: {{ include "nginx-admin.fullname" . }}-config

--- a/charts/nginx-admin/templates/service.yaml
+++ b/charts/nginx-admin/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nginx-admin.fullname" . }}
+spec:
+  selector:
+    app: {{ include "nginx-admin.fullname" . }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: 80
+  type: {{ .Values.service.type }}

--- a/charts/nginx-admin/values.yaml
+++ b/charts/nginx-admin/values.yaml
@@ -1,0 +1,11 @@
+nginxAdmin:
+  replicaCount: 1
+
+  image:
+    repository: nginx
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80


### PR DESCRIPTION
- nginx-client / nginx-admin 각각의 Helm Chart 디렉토리 생성
- Dockerfile, nginx.conf, Helm templates(deployment, service, configmap) 작성
- 공통 _helpers.tpl 정의
- ConfigMap을 통한 nginx.conf 마운트 방식 적용
- SPA 대응을 위한 try_files $uri 설정 반영
- values.yaml에 image, service 항목 포함