### PR TITLE
MNMS-163 :package: feat(booking): Redis 서브차트 의존성 추가 및 구성 완료

### DIFF
--- a/charts/api/charts/booking/Chart.lock
+++ b/charts/api/charts/booking/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: api-booking-database
+  repository: file://./charts/database
+  version: 0.1.0
+- name: api-booking-redis
+  repository: file://./charts/redis
+  version: 0.1.0
+digest: sha256:4fb6e79f98009b0d936065b3353c9c58f75c95490da5bf1a08fe8143decb4abd
+generated: "2025-08-06T10:12:22.2963493+09:00"

--- a/charts/api/charts/booking/Chart.yaml
+++ b/charts/api/charts/booking/Chart.yaml
@@ -9,3 +9,6 @@ dependencies:
   - name: api-booking-database
     version: 0.1.0
     repository: "file://./charts/database"
+  - name: api-booking-redis
+    version: 0.1.0
+    repository: "file://./charts/redis"

--- a/charts/api/charts/booking/charts/redis/Chart.yaml
+++ b/charts/api/charts/booking/charts/redis/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: api-booking-redis
+description: Redis chart for api-booking
+type: application
+version: 0.1.0
+appVersion: "7.2.4"

--- a/charts/api/charts/booking/charts/redis/templates/_helpers.tpl
+++ b/charts/api/charts/booking/charts/redis/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "bookingredis.appName" -}}api-booking-redis{{- end }}
+{{- define "bookingredis.fullname" -}}{{ .Release.Name }}-{{ include "bookingredis.appName" . }}{{- end }}
+
+{{- define "bookingredis.serviceName" -}}
+{{- $g := .Values.global | default (dict) -}}
+{{- $svc := $g.service | default (dict) -}}
+{{- $name := $svc.apiBookingRedis | default "api-booking-redis-service" -}}
+{{- $name -}}
+{{- end }}

--- a/charts/api/charts/booking/charts/redis/templates/service.yaml
+++ b/charts/api/charts/booking/charts/redis/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bookingredis.serviceName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bookingredis.appName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ ( .Values.service | default (dict) ).type | default "ClusterIP" }}
+  ports:
+    - port: {{ ( .Values.service | default (dict) ).port | default 6379 }}
+      targetPort: 6379
+  selector:
+    app.kubernetes.io/name: {{ include "bookingredis.appName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/api/charts/booking/charts/redis/templates/statefulset.yaml
+++ b/charts/api/charts/booking/charts/redis/templates/statefulset.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "bookingredis.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bookingredis.appName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ include "bookingredis.serviceName" . }}
+  replicas: {{ default 1 .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bookingredis.appName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bookingredis.appName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: redis
+          {{- $image := .Values.image | default (dict) }}
+          image: "{{ $image.repository | default "redis" }}:{{ $image.tag | default "7.2.4" }}"
+          imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            {{- $p := .Values.persistence | default (dict) }}
+            storage: {{ $p.size | default "8Gi" }}
+        {{- if $p.storageClass }}
+        storageClassName: {{ $p.storageClass | quote }}
+        {{- end }}

--- a/charts/api/charts/booking/charts/redis/values.yaml
+++ b/charts/api/charts/booking/charts/redis/values.yaml
@@ -1,0 +1,17 @@
+apiBookingRedis:
+  replicaCount: 1
+
+  image:
+    repository: redis
+    tag: "7.2.4"
+    pullPolicy: IfNotPresent
+
+  service:
+    name: api-booking-redis-service
+    type: ClusterIP
+    port: 6379
+
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: ""

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,7 @@ global:
     apiGateway: api-gateway-service
     apiBooking: api-booking-service
     apiBookingDatabase: api-booking-database-service
+    apiBookingRedis: api-booking-redis-service
     apiFestival: api-festival-service
     apiFestivalDatabase: api-festival-database-service
     apiPayment: api-payment-service


### PR DESCRIPTION
- api-booking-redis 차트 생성 (StatefulSet, Service, PVC 포함)
- Helm Chart.yaml 및 Chart.lock에 Redis 의존성 추가
- values.yaml에 global.service.apiBookingRedis 항목 추가
- Redis 기본 이미지(redis:7.2.4) 사용, persistence 8Gi 설정